### PR TITLE
🛠️ Migrate README banner images to WebP format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <a href="https://github.com/bastndev/Lynx-Theme-Pro/releases/latest"><img src="https://raw.githubusercontent.com/bastndev/Lynx-Theme-Pro/refs/heads/main/public/banner.png" width="100%" alt="Lynx Theme Pro Banner"></a>
+  <a href="https://github.com/bastndev/Lynx-Theme-Pro/releases/latest"><img src="https://raw.githubusercontent.com/bastndev/Lynx-Theme-Pro/refs/heads/main/public/banner.webp" width="100%" alt="Lynx Theme Pro Banner"></a>
 </div>
 
 <p align="center">

--- a/public/docs/README_AR.md
+++ b/public/docs/README_AR.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <a href="https://github.com/bastndev/Lynx-Theme-Pro/releases/latest"><img src="https://raw.githubusercontent.com/bastndev/Lynx-Theme-Pro/refs/heads/main/public/banner.png" width="100%" alt="شعار Lynx Theme Pro"></a>
+  <a href="https://github.com/bastndev/Lynx-Theme-Pro/releases/latest"><img src="https://raw.githubusercontent.com/bastndev/Lynx-Theme-Pro/refs/heads/main/public/banner.webp" width="100%" alt="شعار Lynx Theme Pro"></a>
 </div>
 
 <p align="center">

--- a/public/docs/README_DE.md
+++ b/public/docs/README_DE.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <a href="https://github.com/bastndev/Lynx-Theme-Pro/releases/latest"><img src="https://raw.githubusercontent.com/bastndev/Lynx-Theme-Pro/refs/heads/main/public/banner.png" width="100%" alt="Lynx Theme Pro Banner"></a>
+  <a href="https://github.com/bastndev/Lynx-Theme-Pro/releases/latest"><img src="https://raw.githubusercontent.com/bastndev/Lynx-Theme-Pro/refs/heads/main/public/banner.webp" width="100%" alt="Lynx Theme Pro Banner"></a>
 </div>
 
 <p align="center">

--- a/public/docs/README_ES.md
+++ b/public/docs/README_ES.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <a href="https://github.com/bastndev/Lynx-Theme-Pro/releases/latest"><img src="https://raw.githubusercontent.com/bastndev/Lynx-Theme-Pro/refs/heads/main/public/banner.png" width="100%" alt="Banner de Lynx Theme Pro"></a>
+  <a href="https://github.com/bastndev/Lynx-Theme-Pro/releases/latest"><img src="https://raw.githubusercontent.com/bastndev/Lynx-Theme-Pro/refs/heads/main/public/banner.webp" width="100%" alt="Banner de Lynx Theme Pro"></a>
 </div>
 
 <p align="center">

--- a/public/docs/README_FR.md
+++ b/public/docs/README_FR.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <a href="https://github.com/bastndev/Lynx-Theme-Pro/releases/latest"><img src="https://raw.githubusercontent.com/bastndev/Lynx-Theme-Pro/refs/heads/main/public/banner.png" width="100%" alt="Bannière Lynx Theme Pro"></a>
+  <a href="https://github.com/bastndev/Lynx-Theme-Pro/releases/latest"><img src="https://raw.githubusercontent.com/bastndev/Lynx-Theme-Pro/refs/heads/main/public/banner.webp" width="100%" alt="Bannière Lynx Theme Pro"></a>
 </div>
 
 <p align="center">

--- a/public/docs/README_HI.md
+++ b/public/docs/README_HI.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <a href="https://github.com/bastndev/Lynx-Theme-Pro/releases/latest"><img src="https://raw.githubusercontent.com/bastndev/Lynx-Theme-Pro/refs/heads/main/public/banner.png" width="100%" alt="Lynx Theme Pro बैनर"></a>
+  <a href="https://github.com/bastndev/Lynx-Theme-Pro/releases/latest"><img src="https://raw.githubusercontent.com/bastndev/Lynx-Theme-Pro/refs/heads/main/public/banner.webp" width="100%" alt="Lynx Theme Pro बैनर"></a>
 </div>
 
 <p align="center">

--- a/public/docs/README_JA.md
+++ b/public/docs/README_JA.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <a href="https://github.com/bastndev/Lynx-Theme-Pro/releases/latest"><img src="https://raw.githubusercontent.com/bastndev/Lynx-Theme-Pro/refs/heads/main/public/banner.png" width="100%" alt="Lynx Theme Pro バナー"></a>
+  <a href="https://github.com/bastndev/Lynx-Theme-Pro/releases/latest"><img src="https://raw.githubusercontent.com/bastndev/Lynx-Theme-Pro/refs/heads/main/public/banner.webp" width="100%" alt="Lynx Theme Pro バナー"></a>
 </div>
 
 <p align="center">

--- a/public/docs/README_KO.md
+++ b/public/docs/README_KO.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <a href="https://github.com/bastndev/Lynx-Theme-Pro/releases/latest"><img src="https://raw.githubusercontent.com/bastndev/Lynx-Theme-Pro/refs/heads/main/public/banner.png" width="100%" alt="Lynx Theme Pro 배너"></a>
+  <a href="https://github.com/bastndev/Lynx-Theme-Pro/releases/latest"><img src="https://raw.githubusercontent.com/bastndev/Lynx-Theme-Pro/refs/heads/main/public/banner.webp" width="100%" alt="Lynx Theme Pro 배너"></a>
 </div>
 
 <p align="center">

--- a/public/docs/README_PT.md
+++ b/public/docs/README_PT.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <a href="https://github.com/bastndev/Lynx-Theme-Pro/releases/latest"><img src="https://raw.githubusercontent.com/bastndev/Lynx-Theme-Pro/refs/heads/main/public/banner.png" width="100%" alt="Banner do Lynx Theme Pro"></a>
+  <a href="https://github.com/bastndev/Lynx-Theme-Pro/releases/latest"><img src="https://raw.githubusercontent.com/bastndev/Lynx-Theme-Pro/refs/heads/main/public/banner.webp" width="100%" alt="Banner do Lynx Theme Pro"></a>
 </div>
 
 <p align="center">

--- a/public/docs/README_RU.md
+++ b/public/docs/README_RU.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <a href="https://github.com/bastndev/Lynx-Theme-Pro/releases/latest"><img src="https://raw.githubusercontent.com/bastndev/Lynx-Theme-Pro/refs/heads/main/public/banner.png" width="100%" alt="Lynx Theme Pro Баннер"></a>
+  <a href="https://github.com/bastndev/Lynx-Theme-Pro/releases/latest"><img src="https://raw.githubusercontent.com/bastndev/Lynx-Theme-Pro/refs/heads/main/public/banner.webp" width="100%" alt="Lynx Theme Pro Баннер"></a>
 </div>
 
 <p align="center">

--- a/public/docs/README_VI.md
+++ b/public/docs/README_VI.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <a href="https://github.com/bastndev/Lynx-Theme-Pro/releases/latest"><img src="https://raw.githubusercontent.com/bastndev/Lynx-Theme-Pro/refs/heads/main/public/banner.png" width="100%" alt="Lynx Theme Pro Banner"></a>
+  <a href="https://github.com/bastndev/Lynx-Theme-Pro/releases/latest"><img src="https://raw.githubusercontent.com/bastndev/Lynx-Theme-Pro/refs/heads/main/public/banner.webp" width="100%" alt="Lynx Theme Pro Banner"></a>
 </div>
 
 <p align="center">

--- a/public/docs/README_ZH.md
+++ b/public/docs/README_ZH.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <a href="https://github.com/bastndev/Lynx-Theme-Pro/releases/latest"><img src="https://raw.githubusercontent.com/bastndev/Lynx-Theme-Pro/refs/heads/main/public/banner.png" width="100%" alt="Lynx Theme Pro 横幅"></a>
+  <a href="https://github.com/bastndev/Lynx-Theme-Pro/releases/latest"><img src="https://raw.githubusercontent.com/bastndev/Lynx-Theme-Pro/refs/heads/main/public/banner.webp" width="100%" alt="Lynx Theme Pro 横幅"></a>
 </div>
 
 <p align="center">


### PR DESCRIPTION
This pull request updates the banner image in the main `README.md` and all translated documentation files to use the `.webp` format instead of `.png`. This change improves image loading performance and reduces file size across all documentation.

Documentation updates:

* Updated the banner image in `README.md` and all localized README files (Arabic, German, Spanish, French, Hindi, Japanese, Korean, Portuguese, Russian, Vietnamese, Chinese) to use `banner.webp` instead of `banner.png` for improved performance. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2-R2) [[2]](diffhunk://#diff-b1c2a4c682246e1ea96779bdba2706a408006f2eeaa94db82f86ad2ad3c9381bL2-R2) [[3]](diffhunk://#diff-17b72f0e88942b4d71239af916af346b99c65e9b628aef2ddd52c61e838f17eeL2-R2) [[4]](diffhunk://#diff-72af73621d1adde2e4e6d64798c648b3e6675919524872fa98a1f41de1ade59eL2-R2) [[5]](diffhunk://#diff-a69599416d58fee383fe46d926cc58a44f0a163e3854f46565df3e095da97403L2-R2) [[6]](diffhunk://#diff-6e8986d02acfad70ccf066ba68da38159d15177b7a9aac2a399ae366d718601cL2-R2) [[7]](diffhunk://#diff-4f03d8b595320ddd2343a7b986f4dc0d43d540c14bf43a2487c6db5b1483dc4eL2-R2) [[8]](diffhunk://#diff-085478a819e6adc879c96c1a264f7f993f280344d38fd5ee02473659fc7fa548L2-R2) [[9]](diffhunk://#diff-469f0d8c24e30811ce480352f5f75506ea755a12860d2aac22146fe282838389L2-R2) [[10]](diffhunk://#diff-30069dc72e7bd241ae09605fb4adf01f892ea86352035e20efb325c3f48d8633L2-R2) [[11]](diffhunk://#diff-5c736c89ca50b94e106d8319d3a33b94e7dbb8f946639f1454ea6c97c89da9cbL2-R2) [[12]](diffhunk://#diff-6caccf34715f8aae9057103368c297c33f48013e8412110eb8fa5e9a6474427bL2-R2)